### PR TITLE
chore(node): update node compatibility for v0.10.x and above

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/app.js
+++ b/app.js
@@ -1,85 +1,97 @@
-var express = require('express');
-var EventEmitter = require('events').EventEmitter;
+var express = require("express");
+var EventEmitter = require("events").EventEmitter;
 var emitter = new EventEmitter();
-var app = express.createServer();
-var fs = require('fs');
+var bodyParser = require("body-parser");
+var fs = require("fs");
+
+var app = express();
 
 var eventQueue = [];
 var queueStart = 0;
+var port = process.env.PORT;
 
-app.configure(function(){
+app.use(bodyParser.urlencoded({ extended: true }));
+
+if (process.env.NODE_ENV === "production") {
+  port = process.env.PORT || 80;
+} else {
   emitter.setMaxListeners(0);
-  app.use(express.logger());
-  app.set('port', process.env.PORT || 3000);
-  app.use(express.bodyParser());
-  app.use(express.static(__dirname + '/public', { maxAge: 86400}));
-});
-
-// Run on port 80 when in production mode
-app.configure('production', function(){
-  app.use(express.errorHandler()); 
-  app.set('port', process.env.PORT || 80);
-});
+  port = process.env.PORT || 3000;
+  app.use(express.static(__dirname + "/public", { maxAge: 86400 }));
+}
 
 // receives connect events
-app.post('/connect', function(req, res){
-    eventQueue.push({ua: req.body.ua});
-    emitter.emit("connect", req.body.ua);
-    res.end();
+app.post("/connect", function (req, res) {
+  eventQueue.push({ ua: req.body.ua });
+  emitter.emit("connect", req.body.ua);
+  res.end();
 });
 
-
 // receives draw events
-app.post('/draw', function(req, res){
-    eventQueue.push({from: req.body.from, to: req.body.to});
-    emitter.emit("path", req.body.from, req.body.to, eventQueue.length);
-    res.end();
+app.post("/draw", function (req, res) {
+  eventQueue.push({ from: req.body.from, to: req.body.to });
+  emitter.emit("path", req.body.from, req.body.to, eventQueue.length);
+  res.end();
 });
 
 // receives clear signal
-app.post('/clear', function(req, res){
-    queueStart = eventQueue.length;
-    emitter.emit("clear");
-    res.end();
+app.post("/clear", function (req, res) {
+  queueStart = eventQueue.length;
+  emitter.emit("clear");
+  res.end();
 });
 
-app.get('/', function(req, res) {
-    fs.readFile(__dirname + '/public/index.html', 'utf8', function(err, text){
-        response.send(text);
-    });
+app.get("/", function (req, res) {
+  fs.readFile(__dirname + "/public/index.html", "utf8", function (err, text) {
+    response.send(text);
+  });
 });
 
 // broadcast received draw/clear events
-app.get('/stream', function(req, res) {
-    res.setHeader("Content-Type", 'text/event-stream');
-    res.setHeader("Cache-Control", "no-cache");
-    res.setHeader("Connection", "keep-alive");
-    res.writeHead(200);
-    if (req.headers["last-event-id"]) {
-	console.log("Last-Event-ID: " + req.headers["last-event-id"]);
-	for(var i=Math.max(queueStart,req.headers["last-event-id"]) ; i<eventQueue.length;i++) {
-	    res.write("data: " + JSON.stringify({'from': eventQueue[i].from, 'to': eventQueue[i].to}) + "\n");
-	    res.write("id:" + i + "\n\n");
-	}
+app.get("/stream", function (req, res) {
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Connection", "keep-alive");
+  res.writeHead(200);
+  if (req.headers["last-event-id"]) {
+    console.log("Last-Event-ID: " + req.headers["last-event-id"]);
+    for (
+      var i = Math.max(queueStart, req.headers["last-event-id"]);
+      i < eventQueue.length;
+      i++
+    ) {
+      res.write(
+        "data: " +
+          JSON.stringify({ from: eventQueue[i].from, to: eventQueue[i].to }) +
+          "\n"
+      );
+      res.write("id:" + i + "\n\n");
     }
-    // Heroku requires activity to avoid request timeout
-    setInterval(function() { res.write(":\n"); }, 30);
+  }
+  // Heroku requires activity to avoid request timeout
+  setInterval(function () {
+    res.write(":\n");
+  }, 30);
 
-    emitter.on("path", function(from, to, id) {
-	res.write("data: " + JSON.stringify({'from': from, 'to': to})+ "\n");
-	res.write("id: " + id + "\n\n");
-    });
-    emitter.on("clear", function() {
-	res.write("event: clear\n");
-	res.write("id: \n");
-	res.write("data: \n\n");
-    });
-    emitter.on("connect", function(ua) {
-	res.write("event: connect\n");
-	res.write("data: " + JSON.stringify({'ua': ua})+ "\n\n");
-    });
-
+  emitter.on("path", function (from, to, id) {
+    res.write("data: " + JSON.stringify({ from: from, to: to }) + "\n");
+    res.write("id: " + id + "\n\n");
+  });
+  emitter.on("clear", function () {
+    res.write("event: clear\n");
+    res.write("id: \n");
+    res.write("data: \n\n");
+  });
+  emitter.on("connect", function (ua) {
+    res.write("event: connect\n");
+    res.write("data: " + JSON.stringify({ ua: ua }) + "\n\n");
+  });
 });
 
-app.listen(app.set('port'));
-console.log("Express server listening on port %d in %s mode", app.address().port, app.settings.env);
+app.listen(port, () => {
+  console.log(
+    "Express server listening on port %d in %s mode",
+    port,
+    app.settings.env
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,851 @@
+{
+  "name": "node-sharedcanvas",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node-sharedcanvas",
+      "version": "0.0.1",
+      "dependencies": {
+        "body-parser": "^1.20.0",
+        "express": "4.18.1"
+      },
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.0",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.18.1",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.0",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.10.3",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "license": "MIT"
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "license": "MIT"
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.0",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.10.3",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.18.0",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.15.0",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.8",
+      "requires": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1"
+    },
+    "body-parser": {
+      "version": "1.20.0",
+      "requires": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.10.3",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      }
+    },
+    "bytes": {
+      "version": "3.1.2"
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "content-disposition": {
+      "version": "0.5.4",
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4"
+    },
+    "cookie": {
+      "version": "0.5.0"
+    },
+    "cookie-signature": {
+      "version": "1.0.6"
+    },
+    "debug": {
+      "version": "2.6.9",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "2.0.0"
+    },
+    "destroy": {
+      "version": "1.2.0"
+    },
+    "ee-first": {
+      "version": "1.1.1"
+    },
+    "encodeurl": {
+      "version": "1.0.2"
+    },
+    "escape-html": {
+      "version": "1.0.3"
+    },
+    "etag": {
+      "version": "1.8.1"
+    },
+    "express": {
+      "version": "4.18.1",
+      "requires": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.0",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.10.3",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "finalhandler": {
+      "version": "1.2.0",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.2.0"
+    },
+    "fresh": {
+      "version": "0.5.2"
+    },
+    "function-bind": {
+      "version": "1.1.1"
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3"
+    },
+    "http-errors": {
+      "version": "2.0.0",
+      "requires": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4"
+    },
+    "ipaddr.js": {
+      "version": "1.9.1"
+    },
+    "media-typer": {
+      "version": "0.3.0"
+    },
+    "merge-descriptors": {
+      "version": "1.0.1"
+    },
+    "methods": {
+      "version": "1.1.2"
+    },
+    "mime": {
+      "version": "1.6.0"
+    },
+    "mime-db": {
+      "version": "1.52.0"
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0"
+    },
+    "negotiator": {
+      "version": "0.6.3"
+    },
+    "object-inspect": {
+      "version": "1.12.0"
+    },
+    "on-finished": {
+      "version": "2.4.1",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3"
+    },
+    "path-to-regexp": {
+      "version": "0.1.7"
+    },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "qs": {
+      "version": "6.10.3",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1"
+    },
+    "raw-body": {
+      "version": "2.5.1",
+      "requires": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1"
+    },
+    "safer-buffer": {
+      "version": "2.1.2"
+    },
+    "send": {
+      "version": "0.18.0",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3"
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.15.0",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.2.0"
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "statuses": {
+      "version": "2.0.1"
+    },
+    "toidentifier": {
+      "version": "1.0.1"
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0"
+    },
+    "utils-merge": {
+      "version": "1.0.1"
+    },
+    "vary": {
+      "version": "1.1.2"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "node-sharedcanvas",
   "version": "0.0.1",
   "dependencies": {
-    "express": "2.4.2"
+    "body-parser": "^1.20.0",
+    "express": "4.18.1"
   },
   "devDependencies": {},
   "engines": {
@@ -13,5 +14,8 @@
   "repository": {
     "url": ""
   },
-  "main": "apps.js"
+  "scripts": {
+    "start": "node app.js"
+  },
+  "main": "app.js"
 }


### PR DESCRIPTION
1. fix `package.json` app entry and add script start.
1. upgrade node version compatibility. [drop support for node below v0.10.x] more users on node v14.18.3 and above.

-- example
`npm run start` 
![Screen Shot 2022-05-17 at 4 23 59 PM](https://user-images.githubusercontent.com/8095978/168903519-9ed188ea-7a73-4f54-bc40-76ca9c0ef46c.png)
